### PR TITLE
Set isLoading to false in logOut action

### DIFF
--- a/_posts/2019/2019-05-03-why-i-love-usereducer.md
+++ b/_posts/2019/2019-05-03-why-i-love-usereducer.md
@@ -155,6 +155,7 @@ function loginReducer(state, action) {
       return {
         ...state,
         isLoggedIn: false,
+        isLoading: false,
       };
     }
     default:


### PR DESCRIPTION
Currently, the `logOut` action doesn't toggle off the `isLoading` state so the button stays "loading"